### PR TITLE
Add noop adapter as example.

### DIFF
--- a/src/main/java/org/uofm/ot/activator/adapter/NoopAdapter.java
+++ b/src/main/java/org/uofm/ot/activator/adapter/NoopAdapter.java
@@ -1,0 +1,57 @@
+package org.uofm.ot.activator.adapter;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.uofm.ot.activator.exception.OTExecutionStackException;
+import org.springframework.stereotype.Component;
+
+/**
+ * This dummy implementation of a PayloadAdapter does not execute the contents. Instead it simply
+ * returns a dummy instance of whatever return type was specified.
+ *
+ * Created by grosscol on 5/19/17.
+ */
+@Component
+public class NoopAdapter implements ServiceAdapter {
+
+    /**
+     * Implementation that does nothing with the parameter or payload contents.
+     *
+     * @param args Map of parameters. Ignored.
+     * @param code Code to execute. Ignored.
+     * @param functionName Name of function in code to execute. Ignored.
+     * @param returnType Class of Java object to return.
+     * @return a new object of type specified by parameter clazz.
+     */
+    @Override
+    public Object execute(Map<String, Object> args, String code, String functionName, Class returnType) throws OTExecutionStackException {
+        Object retVal;
+
+        if(returnType==Integer.class)       retVal = 0;
+        else if(returnType == Long.class)   retVal = 0L;
+        else if(returnType == Float.class)  retVal = 0.0f;
+        else if(returnType == Double.class) retVal = 0.0;
+        else if(returnType == Map.class)    retVal = new HashMap<String, Object>();
+        else retVal = defaultInitializer(returnType);
+
+        return retVal;
+    }
+
+    /**
+     * Attempt to create an instances of Class<T>
+     * @param returnType Class to instantiate
+     * @return freshly initialized instance of returnType.
+     */
+    private Object defaultInitializer(Class returnType) {
+        try {
+            Object retObject;
+            retObject = returnType.newInstance();
+            return retObject;
+        } catch (IllegalAccessException | InstantiationException illEx) {
+            OTExecutionStackException otEx;
+            String msg = "Could not instantiate return object for: " + returnType.toString();
+            otEx = new OTExecutionStackException(msg, illEx);
+            throw (otEx);
+        }
+    }
+}

--- a/src/test/java/org/uofm/ot/activator/adapter/NoopAdapterTest.java
+++ b/src/test/java/org/uofm/ot/activator/adapter/NoopAdapterTest.java
@@ -1,0 +1,79 @@
+package org.uofm.ot.activator.adapter;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.uofm.ot.activator.exception.OTExecutionStackException;
+
+/**
+ * Created by grosscol on 5/24/17.
+ */
+public class NoopAdapterTest {
+    Map<String, Object> args;
+
+    @Rule
+    public ExpectedException expectedEx = ExpectedException.none();
+
+    @Before
+    public void setUp() {
+        args = new HashMap<>();
+    }
+
+    @Test
+    public void executeEmptyPayload() throws Exception {
+        ServiceAdapter adapter = new NoopAdapter();
+
+        assertThat(adapter.execute(args, "", "", Object.class), instanceOf(Object.class));
+    }
+
+    @Test
+    public void executeNonEmptyPayload() throws Exception {
+        ServiceAdapter adapter = new NoopAdapter();
+        assertThat(adapter.execute(args, "funcName()", "funcName", Object.class), instanceOf(Object.class));
+    }
+
+    @Test
+    public void returnStandardTypes() throws Exception {
+        ServiceAdapter adapter = new NoopAdapter();
+
+        Class[] types = {Integer.class, Long.class, String.class,
+                Float.class, Double.class, Map.class};
+
+        for (Class type : types) {
+            assertThat(adapter.execute(args, "code", "funcName", type), instanceOf(type));
+        }
+    }
+
+    static class ZeroArgInit {
+        ZeroArgInit(){ }
+    }
+
+    static class InitNeedsArgs{
+        InitNeedsArgs(int bar){ }
+    }
+
+    @Test
+    public void usingReturnTypeWithDefaultInit() throws Exception{
+        ServiceAdapter adapter = new NoopAdapter();
+        Class returnType = ZeroArgInit.class;
+
+        assertThat(adapter.execute(args, "code", "funcName", returnType), instanceOf(returnType));
+    }
+
+    @Test
+    public void usingReturnTypeWithoutDefaultInit() throws Exception{
+        ServiceAdapter adapter = new NoopAdapter();
+        Class returnType = InitNeedsArgs.class;
+
+        expectedEx.expect(OTExecutionStackException.class);
+        expectedEx.expectMessage("Could not instantiate return object for: ");
+        adapter.execute(args, "code", "funcName", returnType);
+    }
+}


### PR DESCRIPTION
Adapter which ignores args, code, and function name.  It simply attempts to return an instance of the class specified by the returnType parameter.

